### PR TITLE
chore: make sure starter sites are refreshed when license is toggled

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -72,10 +72,15 @@ class Admin {
 		return $array;
 	}
 
-	private function get_sites_data() {
+	/**
+	 * Get all the sites data.
+	 *
+	 * @return array
+	 */
+	public function get_sites_data() {
 		$theme_support = get_theme_support( 'themeisle-demo-import' );
 		if ( empty( $theme_support[0] ) || ! is_array( $theme_support[0] ) ) {
-			return null;
+			return array();
 		}
 		$theme_support = $theme_support[0];
 		$sites         = isset( $theme_support['remote'] ) ? $theme_support['remote'] : null;
@@ -234,7 +239,7 @@ class Admin {
 				__( 'If none of the solutions in the guide work, please %1$s with us with the error code below, so we can help you fix this.', 'textdomain' ),
 				sprintf( '<a href="https://themeisle.com/contact">%1$s <i class="dashicons dashicons-external"></i></a>', __( 'get in touch', 'textdomain' ) )
 			),
-			'fsDown'                     => sprintf(
+			'fsDown'                      => sprintf(
 				__( 'It seems that %s is not available. You can contact your site administrator or hosting provider to help you enable it.', 'textdomain' ),
 				sprintf( '<code>WP_Filesystem</code>' )
 			),

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -46,7 +46,7 @@ class Main {
 	 *
 	 * @var Admin
 	 */
-	protected $admin = null;
+	public $admin = null;
 
 	/**
 	 * Method to return path to child class in a Reflective Way.

--- a/includes/Rest_Server.php
+++ b/includes/Rest_Server.php
@@ -33,6 +33,18 @@ class Rest_Server {
 	public function register_endpoints() {
 		register_rest_route(
 			Main::API_ROOT,
+			'/refresh_sites_data',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_sites_data' ),
+				'permission_callback' => function () {
+					return current_user_can( 'manage_options' );
+				},
+			)
+		);
+
+		register_rest_route(
+			Main::API_ROOT,
 			'/install_plugins',
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
@@ -42,6 +54,7 @@ class Rest_Server {
 				},
 			)
 		);
+
 		register_rest_route(
 			Main::API_ROOT,
 			'/import_content',
@@ -95,6 +108,18 @@ class Rest_Server {
 				'permission_callback' => function () {
 					return current_user_can( 'manage_options' );
 				},
+			)
+		);
+	}
+
+	/**
+	 * Refreshes the sites data.
+	 */
+	public function get_sites_data() {
+		return new WP_REST_Response(
+			array(
+				'success' => true,
+				'data'    => Main::instance()->admin->get_sites_data(),
 			)
 		);
 	}


### PR DESCRIPTION
Adds a rest route to fetch the sites data. Used when license is toggled so we can actually refresh the sites inside the Starter Sites tab in the dashboard.

After this is merged, the **composer.lock** file from `neve` should be updated and recommitted.

[closes Codeinwp/neve-pro-addon#705]